### PR TITLE
Update ZGridActivity.java

### DIFF
--- a/zgallery/src/main/java/com/mzelzoghbi/zgallery/activities/ZGridActivity.java
+++ b/zgallery/src/main/java/com/mzelzoghbi/zgallery/activities/ZGridActivity.java
@@ -53,7 +53,7 @@ public final class ZGridActivity extends BaseActivity implements GridClickListen
                 .setToolbarTitleColor(ZColor.WHITE)
                 .setToolbarColorResId(toolbarColorResId)
                 .setSelectedImgPosition(pos)
-                .setTitle("Zak Gallery")
+                .setTitle(this.getIntent() != null ? this.getIntent().getStringExtra("title") : "Gallery")
                 .show();
     }
 }


### PR DESCRIPTION
Maintain gallery title when pushing ZGalleryActivity.

Ps. This is just a quick fix, `title` should be accessible in `BaseActivity` by overriding `AppCompatActivity`'s `getTitle()`, so the `ZGallery` call would be:

    .setToolbarTitleColor(ZColor.WHITE)
    ...
    .setTitle(getTitle().toString())